### PR TITLE
Update Zeevonk's license in the attribution to reflect new license.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ This project is licensed under the GPL-3.0 License. See [LICENSE](LICENSE) for m
 
 This project incorporates code from:
 
-- [zeevonk](https://github.com/BaukeWestendorp/zeevonk) — Copyright (C) 2025 Bauke Westendorp  
-  Licensed under the GNU General Public License v3.0
+- [zeevonk](https://github.com/BaukeWestendorp/zeevonk) — Copyright (C) 2026 Bauke Westendorp  
+  Licensed under the Apache License, Version 2.0
 
 ---
 


### PR DESCRIPTION
Hey Matteo, Interesting project and cool to see my code being of use for others in the field! 

Zeevonk now uses a dual license of MIT or Apache v2.0 to better reflect the Rust open source ecosystem now that it's on crates.io as a library, so I thought I'd update the attribution in here too!